### PR TITLE
(doc) add issue template starter

### DIFF
--- a/.github/ISSUE_TEMPLATE/BoxstarterIssueFeature.md
+++ b/.github/ISSUE_TEMPLATE/BoxstarterIssueFeature.md
@@ -1,0 +1,6 @@
+---
+name: Issue / Feature for Boxstarter
+about: Finding an issue with Boxstarter itself? Functionality you want to see added to it.
+---
+
+Please go to https://github.com/chocolatey/boxstarter/issues and create your issue there. Thank you!

--- a/.github/ISSUE_TEMPLATE/ChocolateyIssueFeature.md
+++ b/.github/ISSUE_TEMPLATE/ChocolateyIssueFeature.md
@@ -1,0 +1,6 @@
+---
+name: Issue / Feature for Chocolatey
+about: Finding an issue with Chocolatey itself? Functionality you want to see added to it.
+---
+
+Please go to https://github.com/chocolatey/choco/issues and create your issue there. Thank you!

--- a/.github/ISSUE_TEMPLATE/FeatureRequest.md
+++ b/.github/ISSUE_TEMPLATE/FeatureRequest.md
@@ -1,0 +1,6 @@
+---
+name: Enhancement / Feature Request
+about: How can we make this work better for you? Is there additional functionality you would love us to consider?
+---
+
+<!-- INSERT ACTUAL TEMPLATE HERE -->

--- a/.github/ISSUE_TEMPLATE/ReportIssue.md
+++ b/.github/ISSUE_TEMPLATE/ReportIssue.md
@@ -1,0 +1,6 @@
+---
+name: Report Issue with Dev Setup Scripts
+about: Did you find unexpected behavior?
+---
+
+<!-- INSERT ACTUAL TEMPLATE HERE -->

--- a/.github/ISSUE_TEMPLATE/SecurityDisclosure.md
+++ b/.github/ISSUE_TEMPLATE/SecurityDisclosure.md
@@ -1,0 +1,6 @@
+---
+name: Security Disclosure / Report
+about: Found a security issue?
+---
+
+STOP RIGHT HERE. Security reports should never start out in the open. Please follow up directly with the team if you have a contact. If not you can always start with the information at https://chocolatey.org/security to see instructions on how to provide the disclosure - the Chocolatey Team can route it to the proper folks if it is not for Chocolatey or Boxstarter. Thank you!


### PR DESCRIPTION
@yodurr @bitcrazed This is what I was talking about with issue templates. A great example of what this looks like is at https://github.com/gep13/FakeRepository (cc @gep13) - I don't have the text for what would be expected for an issue report or a feature request, but this is a good starter to get the decision matrix.