### PR TITLE
Remove GCM installation

### DIFF
--- a/dev_ml_python.ps1
+++ b/dev_ml_python.ps1
@@ -15,7 +15,6 @@ Set-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\
 
 #--- Git ---
 choco install -y git -params '"/GitAndUnixToolsOnPath /WindowsTerminal"'
-choco install -y Git-Credential-Manager-for-Windows
 
 #--- Windows Subsystems/Features ---
 choco install -y Microsoft-Hyper-V-All -source windowsFeatures

--- a/dev_web.ps1
+++ b/dev_web.ps1
@@ -16,7 +16,6 @@ Set-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\
 #--- Tools ---
 choco install -y visualstudiocode
 choco install -y git -params '"/GitAndUnixToolsOnPath /WindowsTerminal"'
-choco install -y Git-Credential-Manager-for-Windows
 choco install -y 7zip.install
 
 #--- Windows Subsystems/Features ---

--- a/dev_web_nodejs.ps1
+++ b/dev_web_nodejs.ps1
@@ -16,7 +16,6 @@ Set-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\
 #--- Tools ---
 choco install -y visualstudiocode
 choco install -y git -params '"/GitAndUnixToolsOnPath /WindowsTerminal"'
-choco install -y Git-Credential-Manager-for-Windows
 choco install -y 7zip.install
 
 #--- Windows Subsystems/Features ---


### PR DESCRIPTION
Remove GCM installation as it is already part of standard Git installation

Fixes #29 