### PR TITLE
Fix: Use `refreshenv` after VS Code installation

### DIFF
--- a/dev_web.ps1
+++ b/dev_web.ps1
@@ -15,6 +15,7 @@ Set-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\
 
 #--- Tools ---
 choco install -y vscode
+refreshenv
 code --install-extension msjsdiag.debugger-for-chrome
 code --install-extension msjsdiag.debugger-for-edge
 

--- a/dev_web_nodejs.ps1
+++ b/dev_web_nodejs.ps1
@@ -15,6 +15,7 @@ Set-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\
 
 #--- Tools ---
 choco install -y vscode
+refreshenv
 code --install-extension msjsdiag.debugger-for-chrome
 code --install-extension msjsdiag.debugger-for-edge
 


### PR DESCRIPTION
Ref: https://github.com/Microsoft/windows-dev-box-setup-scripts/pull/48#discussion_r195328690